### PR TITLE
Remove preview from four templates

### DIFF
--- a/SOURCES/0001-Remove-preview-from-4-json-files.patch
+++ b/SOURCES/0001-Remove-preview-from-4-json-files.patch
@@ -1,0 +1,67 @@
+From 5a95c60aafd6246879165a39c93da41044d42096 Mon Sep 17 00:00:00 2001
+From: Gael Duperrey <gduperrey@vates.tech>
+Date: Tue, 16 Jul 2024 15:36:49 +0200
+Subject: [PATCH] Remove preview from 4 json files
+
+Signed-off-by: Gael Duperrey <gduperrey@vates.tech>
+---
+ json/centos-9.json  | 2 +-
+ json/debian-12.json | 2 +-
+ json/rhel-9.json    | 2 +-
+ json/rocky-9.json   | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/json/centos-9.json b/json/centos-9.json
+index e6b06d2..8f0da28 100644
+--- a/json/centos-9.json
++++ b/json/centos-9.json
+@@ -1,6 +1,6 @@
+ {
+     "uuid": "a3d70e4d-c5ac-4dfb-999b-30a0a7efe546",
+     "reference_label": "centos-9",
+-    "name_label": "CentOS Stream 9 (preview)",
++    "name_label": "CentOS Stream 9",
+     "derived_from": "base-el-7.json"
+ }
+diff --git a/json/debian-12.json b/json/debian-12.json
+index 46d738f..b244fd6 100644
+--- a/json/debian-12.json
++++ b/json/debian-12.json
+@@ -1,7 +1,7 @@
+ {
+     "uuid": "07d91aaa-43f7-430a-bf84-0edb6714df0f",
+     "reference_label": "debian-12",
+-    "name_label": "Debian Bookworm 12 (preview)",
++    "name_label": "Debian Bookworm 12",
+     "derived_from": "base-linux-uefi.json",
+     "min_memory": "1G",
+     "disks": [ { "size": "10G" } ]
+diff --git a/json/rhel-9.json b/json/rhel-9.json
+index 909f14f..4246e83 100644
+--- a/json/rhel-9.json
++++ b/json/rhel-9.json
+@@ -1,7 +1,7 @@
+ {
+     "uuid": "6c91b878-5095-421e-a914-224b3bb1088c",
+     "reference_label": "rhel-9",
+-    "name_label": "Red Hat Enterprise Linux 9 (preview)",
++    "name_label": "Red Hat Enterprise Linux 9",
+     "derived_from": "base-linux-uefi.json",
+     "min_memory": "2G",
+     "disks": [ { "size": "10G" } ]
+diff --git a/json/rocky-9.json b/json/rocky-9.json
+index 3f85f2f..7e3c2ff 100644
+--- a/json/rocky-9.json
++++ b/json/rocky-9.json
+@@ -1,7 +1,7 @@
+ {
+     "uuid": "1a647cf9-99c1-4e9c-b3b4-6b9989c530be",
+     "reference_label": "rocky-9",
+-    "name_label": "Rocky Linux 9 (preview)",
++    "name_label": "Rocky Linux 9",
+     "derived_from": "base-linux-uefi.json",
+     "min_memory": "2G",
+     "disks": [ { "size": "15G" } ]
+-- 
+2.45.2
+

--- a/SPECS/guest-templates-json.spec
+++ b/SPECS/guest-templates-json.spec
@@ -3,7 +3,7 @@
 Name:    guest-templates-json
 Summary: Creates the default guest templates
 Version: 2.0.10
-Release: 1.1%{?xsrel}%{?dist}
+Release: 1.2%{?xsrel}%{?dist}
 License: BSD
 Source0: guest-templates-json-2.0.10.tar.gz
 
@@ -12,6 +12,7 @@ Source1000: almalinux-8.json
 Source1001: almalinux-9.json
 Source1002: centos-stream-8.json
 Source1003: oel-9.json
+Patch1000: 0001-Remove-preview-from-4-json-files.patch
 
 BuildArch: noarch
 
@@ -188,6 +189,9 @@ fi
 %{templatedir}/other-install-media.json
 
 %changelog
+* Tue Jul 16 2024 Gael Duperrey <gduperrey@vates.tech> - 2.0.10-1.2
+- Remove "preview" from templates Centos 9, Debian 12, rhel 9, Rocky 9.
+
 * Tue Jun 18 2024 Samuel Verschelde <stormi-xcp@ylix.fr> - 2.0.10-1.1
 - Sync with 2.0.10-1
 - *** Upstream changelog ***


### PR DESCRIPTION
Remove the word "preview" for templates: Centos 9, Debian 12, rhel 9 and rocky 9.